### PR TITLE
Upgrade siddhi version to 4.1.0 and fix SourceMapper issue

### DIFF
--- a/siddhi-extension-archetype/siddhi-execution/src/main/resources/archetype-resources/pom.xml
+++ b/siddhi-extension-archetype/siddhi-execution/src/main/resources/archetype-resources/pom.xml
@@ -47,7 +47,7 @@
         </profile>
     </profiles>
     <properties>
-        <siddhi.version>4.0.0-M106</siddhi.version>
+        <siddhi.version>4.1.0</siddhi.version>
         <log4j.version>1.2.17.wso2v1</log4j.version>
         <testng.version>6.11</testng.version>
         <jacoco.maven.version>0.7.8</jacoco.maven.version>

--- a/siddhi-extension-archetype/siddhi-io/src/main/resources/archetype-resources/pom.xml
+++ b/siddhi-extension-archetype/siddhi-io/src/main/resources/archetype-resources/pom.xml
@@ -111,11 +111,11 @@
         </plugins>
     </build>
     <properties>
-        <siddhi.version>4.0.0-M106</siddhi.version>
+        <siddhi.version>4.1.0</siddhi.version>
         <log4j.version>1.2.17.wso2v1</log4j.version>
         <carbon.transport.version>4.4.15</carbon.transport.version>
-        <siddhi.map.json.version>4.0.3</siddhi.map.json.version>
-        <siddhi.map.xml.version>4.0.1</siddhi.map.xml.version>
+        <siddhi.map.json.version>4.0.15</siddhi.map.json.version>
+        <siddhi.map.xml.version>4.0.11</siddhi.map.xml.version>
         <jacoco.plugin.version>0.7.9</jacoco.plugin.version>
         <carbon.feature.plugin.version>3.0.0</carbon.feature.plugin.version>
     </properties>

--- a/siddhi-extension-archetype/siddhi-map/src/main/resources/archetype-resources/component/src/main/java/__mapTypeInLowerCase__/sourcemapper/__classNameOfSourceMapper__.java
+++ b/siddhi-extension-archetype/siddhi-map/src/main/resources/archetype-resources/component/src/main/java/__mapTypeInLowerCase__/sourcemapper/__classNameOfSourceMapper__.java
@@ -125,4 +125,18 @@ public class ${classNameOfSourceMapper} extends SourceMapper {
     protected void mapAndProcess(Object eventObject, InputEventHandler inputEventHandler) throws InterruptedException {
 
     }
+
+    /**
+     * Method used by {@link SourceMapper} to determine on how to handle transport properties with null values. If
+     * this returns 'false' then {@link SourceMapper} will drop any event/s with null transport
+     * property values. If this returns
+     * 'true' then {@link SourceMapper} will send events even though they contains null transport properties.
+     * This method will be called after init().
+     *
+     * @return whether {@link SourceMapper} should allow or drop events when transport properties are null.
+     */
+    @Override
+    protected boolean allowNullInTransportProperties() {
+        return false;
+    }
 }

--- a/siddhi-extension-archetype/siddhi-map/src/main/resources/archetype-resources/pom.xml
+++ b/siddhi-extension-archetype/siddhi-map/src/main/resources/archetype-resources/pom.xml
@@ -129,7 +129,7 @@
         </plugins>
     </build>
     <properties>
-        <siddhi.version>4.0.0-M106</siddhi.version>
+        <siddhi.version>4.1.0</siddhi.version>
         <log4j.version>1.2.17.wso2v1</log4j.version>
         <testng.version>6.8</testng.version>
         <jacoco.plugin.version>0.7.9</jacoco.plugin.version>

--- a/siddhi-extension-archetype/siddhi-script/src/main/resources/archetype-resources/pom.xml
+++ b/siddhi-extension-archetype/siddhi-script/src/main/resources/archetype-resources/pom.xml
@@ -195,7 +195,7 @@
         </pluginManagement>
     </build>
     <properties>
-        <siddhi.version>4.0.0-M106</siddhi.version>
+        <siddhi.version>4.1.0</siddhi.version>
         <scala.version>2.11.0</scala.version>
         <scalascriptengine.version>1.3.10</scalascriptengine.version>
         <js.version>4.0.0</js.version>

--- a/siddhi-extension-archetype/siddhi-store/src/main/resources/archetype-resources/pom.xml
+++ b/siddhi-extension-archetype/siddhi-store/src/main/resources/archetype-resources/pom.xml
@@ -47,7 +47,7 @@
         </profile>
     </profiles>
     <properties>
-        <siddhi.version>4.0.0-M106</siddhi.version>
+        <siddhi.version>4.1.0</siddhi.version>
         <log4j.version>1.2.17.wso2v1</log4j.version>
         <testng.version>6.9.10</testng.version>
         <jacoco.maven.version>0.7.8</jacoco.maven.version>


### PR DESCRIPTION
## Purpose
> This will upgrade the siddhi version to 4.1.0 and introduce missing method in  generated SourceMapper class

## Goals
> This is to release the siddhi arche-type repo with respect to SP 4.0.0 release.

## Approach
> Upgrade the siddhi versions and Adding the missing allowNullInTransportProperties in SourceMapper class.

## User stories
> NA

## Release note
> NA

## Documentation
> NA

## Training
> NA

## Certification
> NA

## Marketing
> NA

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> NA

## Related PRs
> NA

## Migrations (if applicable)
> NA

## Test environment
> java version "1.8.0_151"
> Java(TM) SE Runtime Environment (build 1.8.0_151-b12)
> Java HotSpot(TM) 64-Bit Server VM (build 25.151-b12, mixed mode)

 
## Learning
> NA